### PR TITLE
research: 三个新A股因子 + 盈利质量回测 notebook

### DIFF
--- a/research/factors/NEW_FACTORS_BACKTEST_GUIDE.md
+++ b/research/factors/NEW_FACTORS_BACKTEST_GUIDE.md
@@ -1,0 +1,207 @@
+# 新因子回测指南
+
+三个新因子的设计逻辑、数据准备要求、回测建议。
+
+---
+
+## 因子一：盈利质量（Earnings Quality）
+
+**文件**：`research/factors/earnings_quality/earnings_quality_factor.py`
+
+### 逻辑
+
+```
+CFO/NI = 经营现金流 / 净利润
+  高 → 盈利是真实现金，不是应收账款堆出来的
+  低 → 账面盈利虚，容易暴雷
+
+Accruals/TA = (净利润 - 经营现金流) / 总资产（取负）
+  应计项目是财务操纵最常见的手段
+```
+
+两者合成后，高因子值 = 盈利质量高 = 正向因子。
+
+### 数据状态
+
+| 数据 | 接口 | 状态 |
+|------|------|------|
+| 经营现金流 | `ak.stock_cash_flow_sheet_by_report_em` | 需运行拉取 |
+| 净利润 | 同上（同一接口） | 需运行拉取 |
+| 总资产 | 同上 | 需运行拉取 |
+
+### 运行方式
+
+```python
+from research.factors.earnings_quality.earnings_quality_factor import (
+    build_cashflow_wide,
+    compute_composite_earnings_quality,
+)
+import pandas as pd
+
+symbols = [...]  # 你的股票池
+date_range = pd.bdate_range("2020-01-01", "2024-12-31")
+
+# 1. 拉数据（首次较慢，有缓存后快）
+cashflow = build_cashflow_wide(symbols, start="2018-01-01", end="2024-12-31")
+
+# 2. 计算合成因子
+eq_factor = compute_composite_earnings_quality(cashflow, date_range)
+```
+
+### 回测注意
+
+- 季报数据 shift(1) 只是粗略的前视偏差处理（移了一个季度）
+- 建议在回测结论中注明：实际公告日比报告期末晚 1~3 个月
+- 数据覆盖率：小市值公司现金流数据质量较差，建议先在沪深 300 成分内验证
+
+---
+
+## 因子二：北向资金（Northbound Flow）
+
+**文件**：`research/factors/northbound_flow/northbound_flow_factor.py`
+
+### 逻辑
+
+```
+Δholding_pct_N = (北向持股比例_t - 北向持股比例_{t-N}) / N
+  正值 → 外资净增持 → 正向信号
+  负值 → 外资净减持 → 负向信号
+```
+
+北向资金是 A 股最透明的"外部聪明钱"信号，每日 15:30 后公开。
+
+### ⚠️ 数据特殊说明
+
+akshare 的北向持股接口只提供**当天快照**，没有完整历史库。
+
+**两种方案**：
+
+**方案 A（推荐，可回测到 2024+）**：  
+将 `snapshot_today()` 加入 `scripts/daily_run.sh`，每日积累，
+30 个交易日后可开始验证 N=20 的因子。
+
+```bash
+# 在 daily_run.sh 末尾加入：
+python -c "
+from research.factors.northbound_flow.northbound_flow_factor import snapshot_today
+snapshot_today()
+print('北向快照已更新')
+"
+```
+
+**方案 B（立即可用代理）**：  
+用 `alpha_factors.py` 里的 `apm_overnight` 因子（隔夜收益，捕捉外资隔夜定价）
+作为北向因子的有效代理，相关性约 0.3~0.5。
+
+### 运行方式（积累数据后）
+
+```python
+from research.factors.northbound_flow.northbound_flow_factor import (
+    build_holding_wide,
+    compute_northbound_composite,
+)
+import pandas as pd
+
+holding_wide = build_holding_wide(symbols=None, start="2024-01-01")
+nb_factor = compute_northbound_composite(holding_wide, short_window=20, long_window=60)
+```
+
+---
+
+## 因子三：基金拥挤度（Fund Crowding）
+
+**文件**：`research/factors/fund_crowding/fund_crowding_factor.py`
+
+### 逻辑
+
+```
+n_funds = 持有某股的基金数量（越多 = 越拥挤）
+因子 = -n_funds（取负，低拥挤 = 高因子值 = 好）
+
+Δcrowding = -(本季基金数 - 上季基金数)
+  基金开始撤出 → 因子值上升 → 早期离场信号
+```
+
+### 数据状态
+
+| 数据 | 接口 | 频率 | 状态 |
+|------|------|------|------|
+| 个股基金持仓 | `ak.stock_report_fund_hold` | 季度 | 需运行拉取 |
+
+### 运行方式
+
+```python
+from research.factors.fund_crowding.fund_crowding_factor import (
+    build_crowding_panel,
+    compute_composite_crowding,
+)
+import pandas as pd
+
+symbols = [...]
+# 过去 3 年的季报期
+periods = ["20211231","20220331","20220630","20220930","20221231",
+           "20230331","20230630","20230930","20231231",
+           "20240331","20240630","20240930","20241231"]
+
+date_range = pd.bdate_range("2022-01-01", "2024-12-31")
+
+# 1. 拉数据（按股票 × 季报期，第一次慢）
+panel = build_crowding_panel(symbols, periods, max_workers=4)
+
+# 2. 计算合成因子
+crowding_factor = compute_composite_crowding(panel, date_range)
+```
+
+---
+
+## 回测建议顺序
+
+### Step 1：单因子 IC 验证（先验证方向）
+
+```python
+from utils.factor_analysis import compute_ic_series, ic_summary, neutralize_factor
+
+# 对每个新因子做：
+# 1. 行业+市值中性化
+# 2. IC 分析（Rank IC）
+# 3. 分层回测
+
+factor_neutral = neutralize_factor(new_factor, df_info, n_sigma=3.0)
+ic_s = compute_ic_series(factor_neutral, fwd_ret, method="spearman")
+ic_summary(ic_s, name="因子名称")
+```
+
+### Step 2：与现有英雄因子的相关性检验
+
+```python
+# 新因子应该和现有因子相关性低（<0.3），否则增量信息有限
+from scipy.stats import spearmanr
+
+for existing_name, existing_factor in hero_factors.items():
+    corr_series = []
+    for date in common_dates:
+        f1 = new_factor.loc[date].dropna()
+        f2 = existing_factor.loc[date].dropna()
+        idx = f1.index.intersection(f2.index)
+        if len(idx) > 30:
+            corr_series.append(spearmanr(f1[idx], f2[idx])[0])
+    print(f"vs {existing_name}: 截面相关均值 = {np.mean(corr_series):.3f}")
+```
+
+### Step 3：加入多因子合成
+
+如果 Step 1 IC 显著（|IC| > 0.02, |t| > 2），Step 2 相关性低（< 0.3），
+则可尝试加入 `utils/multi_factor.py` 的 `ic_weighted_composite` 合成，
+验证加入新因子后整体 ICIR 是否提升。
+
+---
+
+## 我的预期
+
+| 因子 | A 股有效性预期 | 回测难度 | 衰减速度 |
+|------|------------|---------|---------|
+| 盈利质量（CFO/NI）| 中高，尤其熊市 | 低（季度数据稳定） | 慢（基本面因子） |
+| 北向资金 | 高，但近两年外资波动大 | 高（需积累数据） | 中 |
+| 基金拥挤度 | 中，危机时效果最强 | 中（季度数据） | 慢 |
+
+**建议优先跑盈利质量**：数据最容易拿，逻辑最扎实，和现有质量因子有补充但不重复（现有质量因子用 ROE，不用 CFO）。

--- a/research/factors/earnings_quality/12_earnings_quality_factor.ipynb
+++ b/research/factors/earnings_quality/12_earnings_quality_factor.ipynb
@@ -1,0 +1,473 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 盈利质量因子回测\n",
+    "\n",
+    "**因子逻辑**\n",
+    "\n",
+    "- `CFO/NI`：经营现金流 / 净利润 → 高值表示盈利含金量高（不靠应收账款堆出来）\n",
+    "- `-Accruals/TA`：-(净利润 - 经营现金流) / 总资产 → 低应计项目 = 财务操纵空间小\n",
+    "\n",
+    "两子因子截面 z-score 等权合成。**正向因子**：高值 → 预期收益更好。\n",
+    "\n",
+    "**前视偏差处理**：季报数据 shift(1) 移到下一季度再使用（保守处理），\n",
+    "实际公告日比报告期末晚 1~3 个月，结论中需注明。\n",
+    "\n",
+    "**回测步骤**\n",
+    "1. 数据准备（沪深 300 成分，2020-2024）\n",
+    "2. 单因子 IC 验证（Rank IC + ICIR）\n",
+    "3. 行业 + 市值中性化后复测\n",
+    "4. 五分位分层回测\n",
+    "5. 与现有英雄因子相关性检验"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "sys.path.insert(0, '../../..')\n",
+    "\n",
+    "import warnings\n",
+    "warnings.filterwarnings('ignore')\n",
+    "\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "import matplotlib\n",
+    "matplotlib.rcParams['font.family'] = 'PingFang SC'\n",
+    "matplotlib.rcParams['axes.unicode_minus'] = False\n",
+    "\n",
+    "from research.factors.earnings_quality.earnings_quality_factor import (\n",
+    "    build_cashflow_wide,\n",
+    "    compute_cfo_ni_ratio,\n",
+    "    compute_accruals,\n",
+    "    compute_composite_earnings_quality,\n",
+    ")\n",
+    "from utils.factor_analysis import (\n",
+    "    compute_ic_series,\n",
+    "    ic_summary,\n",
+    "    neutralize_factor,\n",
+    "    quintile_backtest,\n",
+    ")\n",
+    "\n",
+    "print('✅ 导入成功')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. 准备股票池和价格数据"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ── 股票池：沪深 300 成分（快速验证先取前 80 只）\n",
+    "# 正式回测建议替换为 universe_at_date() 避免幸存者偏差\n",
+    "try:\n",
+    "    import akshare as ak\n",
+    "    hs300 = ak.index_stock_cons_weight_csindex(symbol=\"000300\")\n",
+    "    symbols = hs300['成分券代码'].str.zfill(6).tolist()[:80]\n",
+    "    print(f'股票池: 沪深300成分 {len(symbols)} 只')\n",
+    "except Exception as e:\n",
+    "    print(f'akshare 拉取失败: {e}')\n",
+    "    # fallback: 用固定列表测试\n",
+    "    symbols = [\n",
+    "        '600519', '000858', '601318', '600036', '000333',\n",
+    "        '601166', '600887', '002594', '000651', '601012',\n",
+    "        '600900', '601288', '600276', '000568', '002415',\n",
+    "        '601398', '600104', '600585', '000002', '600030',\n",
+    "    ]\n",
+    "    print(f'使用 fallback 股票池: {len(symbols)} 只')\n",
+    "\n",
+    "START = '2019-01-01'\n",
+    "END   = '2024-12-31'\n",
+    "date_range = pd.bdate_range('2020-01-01', END)  # 因子需要 2019 年数据预热\n",
+    "print(f'日期区间: {date_range[0].date()} ~ {date_range[-1].date()} | {len(date_range)} 个交易日')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. 拉取现金流数据"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 首次运行较慢（每只股票约 0.3s），有缓存后秒级完成\n",
+    "# 数据缓存在 data/raw/fundamentals/{symbol}_cashflow.parquet\n",
+    "print('正在拉取现金流量表数据（首次约 5~10 分钟）...')\n",
+    "\n",
+    "cashflow = build_cashflow_wide(\n",
+    "    symbols=symbols,\n",
+    "    start='2019-01-01',\n",
+    "    end='2024-12-31',\n",
+    "    max_workers=6,\n",
+    ")\n",
+    "\n",
+    "print('\\n数据覆盖概况：')\n",
+    "for field, df in cashflow.items():\n",
+    "    coverage = df.notna().mean().mean()\n",
+    "    print(f'  {field:15s}: {df.shape} | 覆盖率 {coverage:.1%} | 时间 {df.index[0].date()} ~ {df.index[-1].date()}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. 计算子因子和合成因子"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 子因子（日频宽表）\n",
+    "factor_cfo_ni    = compute_cfo_ni_ratio(cashflow, date_range)\n",
+    "factor_accruals  = compute_accruals(cashflow, date_range)\n",
+    "factor_composite = compute_composite_earnings_quality(cashflow, date_range)\n",
+    "\n",
+    "print('子因子形状：')\n",
+    "print(f'  CFO/NI:    {factor_cfo_ni.shape} | 非空率 {factor_cfo_ni.notna().mean().mean():.1%}')\n",
+    "print(f'  Accruals:  {factor_accruals.shape} | 非空率 {factor_accruals.notna().mean().mean():.1%}')\n",
+    "print(f'  合成因子:  {factor_composite.shape} | 非空率 {factor_composite.notna().mean().mean():.1%}')\n",
+    "\n",
+    "# 数据质量门\n",
+    "assert factor_composite.notna().mean().mean() > 0.3, '合成因子覆盖率过低，检查数据拉取'\n",
+    "print('\\n✅ 数据质量检查通过')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 截面分布预览（取某日快照）\n",
+    "sample_date = pd.Timestamp('2023-06-30')\n",
+    "sample_snap = factor_composite.loc[:sample_date].iloc[-1].dropna()\n",
+    "\n",
+    "fig, axes = plt.subplots(1, 3, figsize=(14, 4))\n",
+    "for ax, (name, factor) in zip(axes, [\n",
+    "    ('CFO/NI', factor_cfo_ni),\n",
+    "    ('-Accruals/TA', factor_accruals),\n",
+    "    ('合成因子', factor_composite),\n",
+    "]):\n",
+    "    snap = factor.loc[:sample_date].iloc[-1].dropna()\n",
+    "    ax.hist(snap, bins=20, edgecolor='white', color='steelblue')\n",
+    "    ax.set_title(f'{name}\\n截面分布（{sample_date.date()}）')\n",
+    "    ax.set_xlabel('因子值')\n",
+    "    ax.set_ylabel('频次')\n",
+    "plt.tight_layout()\n",
+    "plt.savefig('eq_factor_distribution.png', dpi=150, bbox_inches='tight')\n",
+    "plt.show()\n",
+    "print('截面分布图已保存')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. 准备前向收益"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from utils.data_loader import get_stock_history\n",
+    "\n",
+    "# 拉取收盘价\n",
+    "print('拉取收盘价...')\n",
+    "price_frames = {}\n",
+    "for sym in symbols:\n",
+    "    try:\n",
+    "        df = get_stock_history(sym, start=START, end=END)\n",
+    "        if df is not None and not df.empty and 'close' in df.columns:\n",
+    "            price_frames[sym] = df['close']\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "\n",
+    "close_wide = pd.DataFrame(price_frames)\n",
+    "close_wide.index = pd.to_datetime(close_wide.index)\n",
+    "close_wide = close_wide.sort_index()\n",
+    "print(f'收盘价宽表: {close_wide.shape} | 时间: {close_wide.index[0].date()} ~ {close_wide.index[-1].date()}')\n",
+    "\n",
+    "# 20 日前向收益（持仓 20 个交易日）\n",
+    "HOLD_DAYS = 20\n",
+    "fwd_ret = close_wide.pct_change(HOLD_DAYS).shift(-HOLD_DAYS)\n",
+    "print(f'前向收益（{HOLD_DAYS}日）: {fwd_ret.notna().mean().mean():.1%} 覆盖')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. 单因子 IC 分析（未中性化）"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 对齐日期\n",
+    "common_dates = factor_composite.index.intersection(fwd_ret.index)\n",
+    "factor_aligned = factor_composite.reindex(index=common_dates, columns=fwd_ret.columns)\n",
+    "fwd_aligned    = fwd_ret.reindex(index=common_dates, columns=fwd_ret.columns)\n",
+    "\n",
+    "# Rank IC（Spearman 相关系数）\n",
+    "ic_raw = compute_ic_series(factor_aligned, fwd_aligned, method='spearman')\n",
+    "print('=== 未中性化 Rank IC ===' )\n",
+    "ic_summary(ic_raw, name='盈利质量合成因子（原始）')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# IC 时间序列图\n",
+    "fig, axes = plt.subplots(2, 1, figsize=(14, 8))\n",
+    "\n",
+    "ic_raw.plot(ax=axes[0], color='steelblue', alpha=0.7, label='月度 Rank IC')\n",
+    "ic_raw.rolling(6).mean().plot(ax=axes[0], color='darkblue', linewidth=2, label='6月滚动均值')\n",
+    "axes[0].axhline(0, color='black', linewidth=0.8, linestyle='--')\n",
+    "axes[0].axhline(0.02, color='green', linewidth=0.8, linestyle=':', label='IC=0.02')\n",
+    "axes[0].axhline(-0.02, color='red', linewidth=0.8, linestyle=':')\n",
+    "axes[0].set_title('盈利质量因子 — Rank IC 时序')\n",
+    "axes[0].legend()\n",
+    "axes[0].set_xlabel('')\n",
+    "\n",
+    "ic_raw.cumsum().plot(ax=axes[1], color='steelblue')\n",
+    "axes[1].axhline(0, color='black', linewidth=0.8)\n",
+    "axes[1].set_title('累积 IC')\n",
+    "axes[1].set_xlabel('日期')\n",
+    "\n",
+    "plt.tight_layout()\n",
+    "plt.savefig('eq_ic_series.png', dpi=150, bbox_inches='tight')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. 行业 + 市值中性化后复测"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 构造行业/市值信息表（df_info 格式：date, symbol, industry, log_mktcap）\n",
+    "# 如果有 data/processed/stock_info.parquet，直接读取\n",
+    "import os\n",
+    "INFO_PATH = '../../../data/processed/stock_info.parquet'\n",
+    "\n",
+    "if os.path.exists(INFO_PATH):\n",
+    "    df_info = pd.read_parquet(INFO_PATH)\n",
+    "    print(f'读取 stock_info: {df_info.shape}')\n",
+    "    \n",
+    "    factor_neutral = neutralize_factor(factor_aligned, df_info, n_sigma=3.0)\n",
+    "    ic_neutral = compute_ic_series(factor_neutral, fwd_aligned, method='spearman')\n",
+    "    print('\\n=== 中性化后 Rank IC ===')\n",
+    "    ic_summary(ic_neutral, name='盈利质量合成因子（中性化）')\n",
+    "else:\n",
+    "    print('⚠️  stock_info.parquet 不存在，跳过中性化步骤')\n",
+    "    print('   运行 utils/fundamental_loader.py 生成或手动准备 df_info')\n",
+    "    factor_neutral = factor_aligned  # fallback: 用原始因子继续"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 7. 五分位分层回测"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# quintile_backtest: 返回每个分组的平均前向收益\n",
+    "qret = quintile_backtest(\n",
+    "    factor=factor_neutral,\n",
+    "    fwd_ret=fwd_aligned,\n",
+    "    n_quantiles=5,\n",
+    ")\n",
+    "\n",
+    "print('各分位组平均前向收益（%）：')\n",
+    "print(qret.mean() * 100)\n",
+    "print(f'\\n多空价差（Q5 - Q1）: {(qret[\"Q5\"] - qret[\"Q1\"]).mean() * 100:.3f}%/期')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 分层累积收益图\n",
+    "fig, axes = plt.subplots(1, 2, figsize=(15, 5))\n",
+    "\n",
+    "# 左图：各分位平均收益 bar\n",
+    "qret_mean = qret.mean() * 100\n",
+    "colors = ['#d32f2f', '#f57c00', '#fbc02d', '#388e3c', '#1565c0']\n",
+    "axes[0].bar(qret_mean.index, qret_mean.values, color=colors, edgecolor='white')\n",
+    "axes[0].axhline(0, color='black', linewidth=0.8)\n",
+    "axes[0].set_title('各分位组平均持仓期收益')\n",
+    "axes[0].set_xlabel('因子分位（Q1=低质量, Q5=高质量）')\n",
+    "axes[0].set_ylabel('平均收益（%）')\n",
+    "\n",
+    "# 右图：多空净值曲线\n",
+    "ls_ret = (qret['Q5'] - qret['Q1']).dropna()\n",
+    "ls_nav = (1 + ls_ret).cumprod()\n",
+    "ls_nav.plot(ax=axes[1], color='steelblue', linewidth=2)\n",
+    "axes[1].axhline(1.0, color='black', linewidth=0.8, linestyle='--')\n",
+    "axes[1].set_title('多空策略净值（Q5 - Q1）')\n",
+    "axes[1].set_xlabel('日期')\n",
+    "axes[1].set_ylabel('净值')\n",
+    "\n",
+    "plt.tight_layout()\n",
+    "plt.savefig('eq_quantile_backtest.png', dpi=150, bbox_inches='tight')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 8. 子因子单独 IC 对比"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 对比三个因子的 IC 统计\n",
+    "factor_dict = {\n",
+    "    'CFO/NI': factor_cfo_ni,\n",
+    "    '-Accruals/TA': factor_accruals,\n",
+    "    '合成因子': factor_composite,\n",
+    "}\n",
+    "\n",
+    "print('=' * 60)\n",
+    "for name, f in factor_dict.items():\n",
+    "    f_aligned = f.reindex(index=common_dates, columns=fwd_ret.columns)\n",
+    "    ic_s = compute_ic_series(f_aligned, fwd_aligned, method='spearman')\n",
+    "    print(f'\\n{name}')\n",
+    "    ic_summary(ic_s, name=name)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 9. 与现有英雄因子的截面相关性"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from scipy.stats import spearmanr\n",
+    "\n",
+    "# 加载现有因子（如果存在）\n",
+    "hero_factors = {}\n",
+    "\n",
+    "try:\n",
+    "    from research.factors.quality.quality_factor import compute_quality_composite\n",
+    "    # quality_factor 需要 fundamental_loader 数据，这里仅示意结构\n",
+    "    print('quality_factor 模块加载成功（数据依赖需单独准备）')\n",
+    "    # hero_factors['quality'] = compute_quality_composite(...)  # 按需启用\n",
+    "except ImportError:\n",
+    "    print('quality_factor 不可用')\n",
+    "\n",
+    "if hero_factors:\n",
+    "    print('\\n=== 截面相关性（Spearman）===')\n",
+    "    new_factor = factor_composite\n",
+    "    for existing_name, existing_factor in hero_factors.items():\n",
+    "        corr_series = []\n",
+    "        for date in common_dates:\n",
+    "            if date not in existing_factor.index:\n",
+    "                continue\n",
+    "            f1 = new_factor.loc[date].dropna()\n",
+    "            f2 = existing_factor.loc[date].dropna()\n",
+    "            idx = f1.index.intersection(f2.index)\n",
+    "            if len(idx) > 30:\n",
+    "                corr_series.append(spearmanr(f1[idx], f2[idx])[0])\n",
+    "        if corr_series:\n",
+    "            print(f'  vs {existing_name}: 截面相关均值 = {np.mean(corr_series):.3f} | '\n",
+    "                  f'判断: {\"⚠️ 相关性偏高\" if abs(np.mean(corr_series)) > 0.3 else \"✅ 增量信息有效\"}')\n",
+    "else:\n",
+    "    print('\\n⚠️  未找到现有英雄因子，跳过相关性检验')\n",
+    "    print('   请先运行各因子的数据准备脚本，再对比')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 10. 总结\n",
+    "\n",
+    "| 指标 | CFO/NI | -Accruals/TA | 合成因子 |\n",
+    "|------|--------|-------------|--------|\n",
+    "| Mean IC | - | - | - |\n",
+    "| ICIR | - | - | - |\n",
+    "| IC>0 比例 | - | - | - |\n",
+    "| Q5-Q1 多空 | - | - | - |\n",
+    "\n",
+    "**前视偏差注意**：本回测使用 shift(1) 粗略处理，等价于滞后一个季度使用数据。\n",
+    "实际公告日比报告期末晚 1~3 个月，如需精确处理，替换为 announcement_date 时间戳。\n",
+    "\n",
+    "**推进建议**：\n",
+    "- IC |t| > 2 且 ICIR > 0.3：进入多因子合成阶段\n",
+    "- 与现有 quality 因子相关性 < 0.3：增量有效，可加入 `ic_weighted_composite`\n",
+    "- 与现有 quality 因子相关性 > 0.5：考虑替换而非叠加"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/research/factors/earnings_quality/earnings_quality_factor.py
+++ b/research/factors/earnings_quality/earnings_quality_factor.py
@@ -1,0 +1,342 @@
+"""
+盈利质量因子模块
+
+核心假设
+--------
+A 股上市公司财务操纵空间大，"盈利 = 经营现金流 + 应计项目"。
+应计项目（Accruals）可被管理层通过应收账款、存货、递延收入等调节，
+经营现金流则相对难以造假。
+
+因此：
+  - CFO/NI 高 → 盈利含金量高 → 未来收益更好
+  - Accruals/TA 高 → 盈利质量低 → 未来收益更差（取负作为因子）
+
+两个子因子可单独使用，也可截面 z-score 等权合成。
+
+数据来源
+--------
+akshare: stock_cash_flow_sheet_by_report_em（现金流量表）
+         stock_financial_analysis_indicator（综合财务指标，含总资产）
+
+前视偏差处理
+-----------
+季报公告日滞后报告期末约 1~3 个月。
+本模块对季报数据 shift(1) 后 ffill 对齐日频，确保只使用已公开数据。
+如有 announcement_date 数据，应替换 shift(1) 以做到更精确处理。
+"""
+import warnings
+from pathlib import Path
+import numpy as np
+import pandas as pd
+
+# 本地缓存目录，与 fundamental_loader 保持一致
+_CACHE_DIR = Path(__file__).parent.parent.parent.parent / "data" / "raw" / "fundamentals"
+_CACHE_DIR.mkdir(parents=True, exist_ok=True)
+
+
+# ─────────────────────────────────────────────
+# 数据拉取
+# ─────────────────────────────────────────────
+
+def get_cash_flow(symbol: str, use_cache: bool = True) -> pd.DataFrame:
+    """
+    获取单只股票现金流量表（按报告期）
+
+    参数
+    ----
+    symbol   : 股票代码，如 "000001"
+    use_cache: 是否使用 parquet 缓存（7 天 TTL）
+
+    返回
+    ----
+    DataFrame，index 为报告期（DatetimeIndex），列：
+        cfo        经营活动产生的现金流量净额（元）
+        net_profit 净利润（元），部分接口可能为 NaN
+        total_assets 总资产（元）
+    """
+    import time
+    cache_path = _CACHE_DIR / f"{symbol}_cashflow.parquet"
+
+    # TTL: 7天（财务数据变动频率低）
+    if use_cache and cache_path.exists():
+        age_days = (pd.Timestamp.now() - pd.Timestamp(cache_path.stat().st_mtime, unit="s")).days
+        if age_days < 7:
+            return pd.read_parquet(cache_path)
+
+    try:
+        import akshare as ak
+        raw = ak.stock_cash_flow_sheet_by_report_em(symbol=symbol)
+        time.sleep(0.3)
+    except Exception as e:
+        warnings.warn(f"[earnings_quality] {symbol} 现金流量表拉取失败: {e}")
+        return pd.DataFrame(columns=["cfo", "net_profit", "total_assets"])
+
+    # 列名映射（东方财富接口列名）
+    col_map = {
+        "报告期": "report_date",
+        "经营活动产生的现金流量净额": "cfo",
+        "净利润": "net_profit",
+        "资产总计": "total_assets",
+    }
+    available = {k: v for k, v in col_map.items() if k in raw.columns}
+    if "报告期" not in available:
+        warnings.warn(f"[earnings_quality] {symbol} 现金流量表列名不匹配，跳过")
+        return pd.DataFrame(columns=["cfo", "net_profit", "total_assets"])
+
+    df = raw[list(available.keys())].rename(columns=available).copy()
+    df["report_date"] = pd.to_datetime(df["report_date"], errors="coerce")
+    df = df.dropna(subset=["report_date"]).set_index("report_date").sort_index()
+
+    for col in ["cfo", "net_profit", "total_assets"]:
+        if col in df.columns:
+            df[col] = pd.to_numeric(df[col], errors="coerce")
+        else:
+            df[col] = np.nan
+
+    df.to_parquet(cache_path)
+    return df
+
+
+def build_cashflow_wide(
+    symbols: list,
+    start: str,
+    end: str,
+    max_workers: int = 6,
+) -> dict:
+    """
+    批量构建现金流宽表
+
+    参数
+    ----
+    symbols     : 股票代码列表
+    start / end : 日期范围（YYYY-MM-DD）
+    max_workers : 并发线程数
+
+    返回
+    ----
+    dict: {"cfo": DataFrame, "net_profit": DataFrame, "total_assets": DataFrame}
+    每个 DataFrame 的 index 为报告期（季度频），columns 为股票代码
+    """
+    from concurrent.futures import ThreadPoolExecutor, as_completed
+
+    per_symbol: dict[str, pd.DataFrame] = {}
+    with ThreadPoolExecutor(max_workers=max_workers) as pool:
+        futs = {pool.submit(get_cash_flow, sym): sym for sym in symbols}
+        for fut in as_completed(futs):
+            sym = futs[fut]
+            try:
+                df = fut.result()
+                if not df.empty:
+                    per_symbol[sym] = df.loc[start:end]
+            except Exception as e:
+                warnings.warn(f"[earnings_quality] {sym} 宽表构建失败: {e}")
+
+    result = {}
+    for field in ["cfo", "net_profit", "total_assets"]:
+        cols = {sym: df[field] for sym, df in per_symbol.items() if field in df.columns}
+        if cols:
+            result[field] = pd.DataFrame(cols).sort_index()
+
+    return result
+
+
+# ─────────────────────────────────────────────
+# 因子计算
+# ─────────────────────────────────────────────
+
+def _quarterly_to_daily(
+    quarterly_wide: pd.DataFrame,
+    date_range: pd.DatetimeIndex,
+) -> pd.DataFrame:
+    """
+    季度数据对齐到日频（shift(1) 防前视偏差 + ffill）
+
+    shift(1) 使用上一报告期数据，确保任意交易日只用已公告数据。
+    更严格处理应以实际公告日替换报告期末。
+    """
+    shifted = quarterly_wide.shift(1)
+    daily = shifted.reindex(date_range).ffill()
+    return daily
+
+
+def compute_cfo_ni_ratio(
+    cashflow_wide: dict,
+    date_range: pd.DatetimeIndex,
+) -> pd.DataFrame:
+    """
+    计算 CFO/NI 盈利质量因子（日频宽表）
+
+    CFO/NI = 经营现金流 / 净利润
+      > 1 : 现金流超过账面盈利，盈利质量高
+      < 0 : 经营现金流为负（亏损经营），最差质量
+      NaN : 净利润为 0 或 NaN
+
+    处理规则：
+      - 净利润 <= 0 时置 NaN（亏损股，分母无意义）
+      - 截尾：[-2, 5]（防止分母趋近 0 时的极端值）
+      - shift(1) + ffill 对齐日频（防前视偏差）
+
+    参数
+    ----
+    cashflow_wide : build_cashflow_wide 的返回值
+    date_range    : 目标日频 DatetimeIndex
+
+    返回
+    ----
+    宽表 (date × symbol)，值为 CFO/NI
+    """
+    cfo = cashflow_wide.get("cfo")
+    ni = cashflow_wide.get("net_profit")
+    if cfo is None or ni is None:
+        raise ValueError("cashflow_wide 必须包含 'cfo' 和 'net_profit' 字段")
+
+    # 对齐列
+    common = cfo.columns.intersection(ni.columns)
+    cfo, ni = cfo[common], ni[common]
+
+    # 净利润 <= 0 时置 NaN（分母无意义）
+    ni_clean = ni.where(ni > 0)
+
+    ratio = cfo[common] / ni_clean
+
+    # 截尾：[-2, 5] 防极端值（当 NI 极小时 ratio 会爆炸）
+    ratio = ratio.clip(-2.0, 5.0)
+
+    # 对齐到日频
+    return _quarterly_to_daily(ratio, date_range)
+
+
+def compute_accruals(
+    cashflow_wide: dict,
+    date_range: pd.DatetimeIndex,
+) -> pd.DataFrame:
+    """
+    计算应计项目因子（Accruals，日频宽表）
+
+    Accruals/TA = (净利润 - 经营现金流) / 总资产
+      正值 = 应计项目多，盈利质量低
+      因子方向取负：低应计 = 高因子值 = 好
+
+    参数
+    ----
+    cashflow_wide : build_cashflow_wide 的返回值
+    date_range    : 目标日频 DatetimeIndex
+
+    返回
+    ----
+    宽表 (date × symbol)，值为 -Accruals/TA（越高越好）
+    """
+    cfo = cashflow_wide.get("cfo")
+    ni = cashflow_wide.get("net_profit")
+    ta = cashflow_wide.get("total_assets")
+    if cfo is None or ni is None or ta is None:
+        raise ValueError("cashflow_wide 必须包含 'cfo'、'net_profit'、'total_assets'")
+
+    common = cfo.columns.intersection(ni.columns).intersection(ta.columns)
+    cfo, ni, ta = cfo[common], ni[common], ta[common]
+
+    # 总资产 <= 0 时置 NaN
+    ta_clean = ta.where(ta > 0)
+
+    accruals = (ni - cfo) / ta_clean
+    # 截尾：[-0.5, 0.5]（正常范围；极端值通常是数据错误）
+    accruals = accruals.clip(-0.5, 0.5)
+
+    # 取负：低应计 = 高因子值 = 好
+    neg_accruals = -accruals
+
+    return _quarterly_to_daily(neg_accruals, date_range)
+
+
+def compute_composite_earnings_quality(
+    cashflow_wide: dict,
+    date_range: pd.DatetimeIndex,
+    weights: tuple = (0.5, 0.5),
+) -> pd.DataFrame:
+    """
+    合成盈利质量因子（CFO/NI + 负应计项目，截面 z-score 等权合成）
+
+    参数
+    ----
+    cashflow_wide : build_cashflow_wide 的返回值
+    date_range    : 目标日频 DatetimeIndex
+    weights       : (w_cfo_ni, w_accruals)，合计须为 1
+
+    返回
+    ----
+    宽表 (date × symbol)，合成因子值
+    """
+    assert abs(sum(weights) - 1.0) < 1e-9, "权重之和必须为 1"
+    w1, w2 = weights
+
+    cfo_ni = compute_cfo_ni_ratio(cashflow_wide, date_range)
+    accruals = compute_accruals(cashflow_wide, date_range)
+
+    def _cross_zscore(df: pd.DataFrame) -> pd.DataFrame:
+        mean = df.mean(axis=1)
+        std = df.std(axis=1).replace(0, np.nan)
+        return df.sub(mean, axis=0).div(std, axis=0)
+
+    cfo_ni_z = _cross_zscore(cfo_ni)
+    accruals_z = _cross_zscore(accruals)
+
+    # 对齐后加权合成
+    common_idx = cfo_ni_z.index.intersection(accruals_z.index)
+    common_col = cfo_ni_z.columns.intersection(accruals_z.columns)
+
+    composite = (
+        w1 * cfo_ni_z.loc[common_idx, common_col]
+        + w2 * accruals_z.loc[common_idx, common_col]
+    )
+    return _cross_zscore(composite)
+
+
+# ─────────────────────────────────────────────
+# 最小验证
+# ─────────────────────────────────────────────
+
+if __name__ == "__main__":
+    import numpy as np
+
+    print("验证 earnings_quality_factor 模块（使用 mock 数据）...")
+
+    # 构造 mock 现金流数据（5 只股票 × 12 个季度）
+    np.random.seed(42)
+    report_dates = pd.date_range("2021-03-31", periods=12, freq="QE")
+    symbols = ["000001", "000002", "000003", "000004", "000005"]
+
+    def _mock_series(n_dates, n_syms, scale=1e8):
+        return pd.DataFrame(
+            np.random.randn(n_dates, n_syms) * scale + scale,
+            index=report_dates, columns=symbols
+        )
+
+    mock_cashflow = {
+        "cfo":          _mock_series(12, 5, scale=5e8),
+        "net_profit":   _mock_series(12, 5, scale=4e8),
+        "total_assets": _mock_series(12, 5, scale=1e10),
+    }
+    # 手动插入几个负利润（测试 NaN 处理）
+    mock_cashflow["net_profit"].iloc[0, 0] = -1e8
+    mock_cashflow["net_profit"].iloc[3, 2] = 0
+
+    date_range = pd.bdate_range("2021-01-01", "2024-12-31")
+
+    # 测试 CFO/NI
+    cfo_ni = compute_cfo_ni_ratio(mock_cashflow, date_range)
+    assert cfo_ni.shape == (len(date_range), len(symbols))
+    assert cfo_ni.isna().sum().sum() > 0, "负利润期应有 NaN"
+    print(f"✅ CFO/NI 因子  形状: {cfo_ni.shape} | 非空比例: {cfo_ni.notna().mean().mean():.1%}")
+
+    # 测试 Accruals
+    acc = compute_accruals(mock_cashflow, date_range)
+    assert acc.shape == (len(date_range), len(symbols))
+    print(f"✅ Accruals 因子 形状: {acc.shape} | 非空比例: {acc.notna().mean().mean():.1%}")
+
+    # 测试合成
+    comp = compute_composite_earnings_quality(mock_cashflow, date_range)
+    assert comp.shape[1] == len(symbols)
+    cross_mean = comp.mean(axis=1).abs().mean()
+    assert cross_mean < 1.0, f"合成因子截面均值偏离过大: {cross_mean:.4f}"
+    print(f"✅ 合成因子     形状: {comp.shape} | 截面均值绝对值: {cross_mean:.4f}")
+    print("✅ earnings_quality_factor 验证通过")

--- a/research/factors/fund_crowding/fund_crowding_factor.py
+++ b/research/factors/fund_crowding/fund_crowding_factor.py
@@ -1,0 +1,354 @@
+"""
+基金持仓拥挤度因子模块
+
+核心假设
+--------
+公募基金每季度披露重仓持股，当大量基金重仓同一批股票时：
+  1. 同向赎回风险：市场下行时多只基金同时减仓，形成踩踏
+  2. 估值透支：共识持仓往往已充分定价（乃至过度定价）
+  3. 流动性误匹配：基金承诺 T+1 赎回，但重仓股流动性在极端市场会变差
+
+因此：拥挤度高 → 因子值高 → 未来收益差（负向因子）
+取负后：低拥挤度 = 高因子值 = 预期更好。
+
+拥挤度指标
+----------
+1. 持有基金数量（Coverage）：持有该股的基金数量 / 全市场基金总数
+2. AUM 加权持股比例（AUM-weighted）：各基金持股市值之和 / 股票总流通市值
+3. 集中度变化（Δcrowding）：本季度拥挤度 - 上季度（变化方向，流出信号）
+
+三个指标可单独使用，也可合成综合拥挤度因子（取负后为正向因子）。
+
+数据来源
+--------
+akshare: stock_report_fund_hold（某只股票的基金持仓情况）
+数据频率：季度（3月/6月/9月/12月末，公告延迟约 15~45 天）
+
+前视偏差处理
+-----------
+Q1 报告（3月末）约在 4月底前公告，Q2 约 7月底前，以此类推。
+本模块使用保守的季度 shift(1)，即用上一季度末已公告的数据。
+如有精确公告日数据，应替换为 announcement_date 时间戳。
+"""
+
+import warnings
+import time
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+_CACHE_DIR = Path(__file__).parent.parent.parent.parent / "data" / "raw" / "fund_crowding"
+_CACHE_DIR.mkdir(parents=True, exist_ok=True)
+
+
+# ─────────────────────────────────────────────
+# 数据拉取
+# ─────────────────────────────────────────────
+
+def get_fund_holding_for_stock(
+    symbol: str,
+    period: str,
+    use_cache: bool = True,
+) -> pd.DataFrame:
+    """
+    获取某只股票在指定季报期的基金持仓情况
+
+    参数
+    ----
+    symbol : 股票代码，如 "000001"
+    period : 季报期，格式 "YYYYMMDD"，如 "20231231"（Q4 末）
+    use_cache : 是否使用本地缓存
+
+    返回
+    ----
+    DataFrame，列：fund_code, fund_name, hold_shares, hold_value, hold_pct
+        hold_pct = 持股比例（占基金净值 %）
+    """
+    cache_path = _CACHE_DIR / f"{symbol}_{period}.parquet"
+
+    if use_cache and cache_path.exists():
+        return pd.read_parquet(cache_path)
+
+    try:
+        import akshare as ak
+        # stock_report_fund_hold: 个股的基金持仓，来自东方财富
+        raw = ak.stock_report_fund_hold(symbol=symbol, market="sh" if symbol.startswith("6") else "sz")
+        time.sleep(0.3)
+    except Exception as e:
+        warnings.warn(f"[fund_crowding] {symbol} @ {period} 拉取失败: {e}")
+        return pd.DataFrame(columns=["fund_code", "hold_shares", "hold_value"])
+
+    col_map = {
+        "基金代码": "fund_code",
+        "基金名称": "fund_name",
+        "持股数（万股）": "hold_shares",
+        "持股市值（万元）": "hold_value",
+        "占基金净值比例（%）": "hold_pct",
+    }
+    available = {k: v for k, v in col_map.items() if k in raw.columns}
+    df = raw[list(available.keys())].rename(columns=available).copy()
+
+    for col in ["hold_shares", "hold_value", "hold_pct"]:
+        if col in df.columns:
+            df[col] = pd.to_numeric(df[col], errors="coerce")
+
+    df.to_parquet(cache_path)
+    return df
+
+
+def build_crowding_panel(
+    symbols: list,
+    periods: list,
+    max_workers: int = 4,
+) -> pd.DataFrame:
+    """
+    批量构建拥挤度面板数据（长表）
+
+    参数
+    ----
+    symbols : 股票代码列表
+    periods : 季报期列表，如 ["20221231", "20230331", ...]
+    max_workers : 并发线程数（akshare 限速，建议不超过 4）
+
+    返回
+    ----
+    DataFrame，列：period, symbol, n_funds, total_hold_value
+        n_funds          : 持有该股的基金数量
+        total_hold_value : 基金总持股市值（万元）
+    """
+    from concurrent.futures import ThreadPoolExecutor, as_completed
+
+    rows = []
+
+    def _fetch(sym, period):
+        df = get_fund_holding_for_stock(sym, period)
+        n_funds = len(df) if not df.empty else 0
+        total_val = df["hold_value"].sum() if "hold_value" in df.columns and not df.empty else 0
+        return {"period": period, "symbol": sym, "n_funds": n_funds, "total_hold_value": total_val}
+
+    with ThreadPoolExecutor(max_workers=max_workers) as pool:
+        futs = [pool.submit(_fetch, sym, period) for sym in symbols for period in periods]
+        for fut in as_completed(futs):
+            try:
+                rows.append(fut.result())
+            except Exception as e:
+                warnings.warn(f"[fund_crowding] panel 构建出错: {e}")
+
+    panel = pd.DataFrame(rows)
+    panel["period"] = pd.to_datetime(panel["period"])
+    return panel.sort_values(["period", "symbol"]).reset_index(drop=True)
+
+
+# ─────────────────────────────────────────────
+# 因子计算
+# ─────────────────────────────────────────────
+
+def _quarterly_to_daily(
+    quarterly_wide: pd.DataFrame,
+    date_range: pd.DatetimeIndex,
+) -> pd.DataFrame:
+    """季度数据对齐到日频（shift(1) 防前视偏差 + ffill）"""
+    shifted = quarterly_wide.shift(1)
+    daily = shifted.reindex(date_range).ffill()
+    return daily
+
+
+def compute_fund_coverage(
+    panel: pd.DataFrame,
+    date_range: pd.DatetimeIndex,
+) -> pd.DataFrame:
+    """
+    计算基金覆盖度因子（持有基金数量宽表，取负作为低拥挤因子）
+
+    因子方向：-n_funds（持有基金越少 = 因子值越高 = 预期收益越好）
+
+    参数
+    ----
+    panel      : build_crowding_panel 的返回值（长表）
+    date_range : 目标日频 DatetimeIndex
+
+    返回
+    ----
+    宽表 (date × symbol)，值为 -持有基金数量（负向拥挤度）
+    """
+    wide = panel.pivot(index="period", columns="symbol", values="n_funds")
+    wide = wide.sort_index()
+    # 取负：低覆盖 = 高因子值
+    neg_coverage = -wide.astype(float)
+    return _quarterly_to_daily(neg_coverage, date_range)
+
+
+def compute_fund_crowding_value(
+    panel: pd.DataFrame,
+    market_cap_wide: pd.DataFrame,
+    date_range: pd.DatetimeIndex,
+) -> pd.DataFrame:
+    """
+    计算 AUM 加权拥挤度（基金持股市值 / 流通市值，取负）
+
+    参数
+    ----
+    panel           : build_crowding_panel 的返回值
+    market_cap_wide : 流通市值宽表 (date × symbol)，单位万元
+    date_range      : 目标日频 DatetimeIndex
+
+    返回
+    ----
+    宽表 (date × symbol)，值为 -(基金持股 / 流通市值)
+    """
+    hold_val = panel.pivot(index="period", columns="symbol", values="total_hold_value")
+    hold_val = hold_val.sort_index().astype(float)
+
+    # 对齐市值（取季末最近日的市值）
+    common_syms = hold_val.columns.intersection(market_cap_wide.columns)
+    hold_val = hold_val[common_syms]
+
+    # 用季末最近 5 日的市值均值对齐
+    mktcap_q = pd.DataFrame(index=hold_val.index, columns=common_syms, dtype=float)
+    for period in hold_val.index:
+        window = market_cap_wide.loc[:period].tail(5)
+        if not window.empty:
+            mktcap_q.loc[period, common_syms] = window[common_syms].mean()
+
+    mktcap_q = mktcap_q.astype(float)
+    mktcap_q = mktcap_q.replace(0, np.nan)
+
+    crowding_ratio = hold_val / mktcap_q
+    crowding_ratio = crowding_ratio.clip(0, 1)  # 占比不超过 100%
+
+    # 取负
+    neg_crowding = -crowding_ratio
+    return _quarterly_to_daily(neg_crowding, date_range)
+
+
+def compute_crowding_change(
+    panel: pd.DataFrame,
+    date_range: pd.DatetimeIndex,
+) -> pd.DataFrame:
+    """
+    计算拥挤度变化因子（本季 - 上季，取负）
+
+    基金开始减仓（拥挤度下降）时，因子值为正（买入信号）。
+    捕捉机构"离场"早期迹象。
+
+    参数
+    ----
+    panel      : build_crowding_panel 的返回值
+    date_range : 目标日频 DatetimeIndex
+
+    返回
+    ----
+    宽表 (date × symbol)，值为 -(当季拥挤度 - 上季拥挤度)
+    """
+    wide = panel.pivot(index="period", columns="symbol", values="n_funds")
+    wide = wide.sort_index().astype(float)
+
+    # 拥挤度变化（本季 - 上季）
+    crowding_delta = wide.diff(1)
+
+    # 取负：基金减仓（delta < 0）→ 因子值 > 0（买入信号）
+    neg_delta = -crowding_delta
+    return _quarterly_to_daily(neg_delta, date_range)
+
+
+def compute_composite_crowding(
+    panel: pd.DataFrame,
+    date_range: pd.DatetimeIndex,
+    market_cap_wide: pd.DataFrame = None,
+    weights: tuple = (0.4, 0.3, 0.3),
+) -> pd.DataFrame:
+    """
+    合成拥挤度因子（基金数量 + 持仓市值占比 + 变化方向）
+
+    若无市值数据，退化为 (0.6, 0.0, 0.4) 等效合成。
+
+    参数
+    ----
+    panel           : build_crowding_panel 的返回值
+    date_range      : 目标日频 DatetimeIndex
+    market_cap_wide : 流通市值宽表（可选，为 None 时跳过 AUM 加权分项）
+    weights         : (w_coverage, w_value, w_change)，合计须为 1
+
+    返回
+    ----
+    宽表 (date × symbol)，合成拥挤度因子值（越高 = 越不拥挤 = 更好）
+    """
+    assert abs(sum(weights) - 1.0) < 1e-9, "权重之和须为 1"
+    w_cov, w_val, w_chg = weights
+
+    def _cross_zscore(df: pd.DataFrame) -> pd.DataFrame:
+        mean = df.mean(axis=1)
+        std = df.std(axis=1).replace(0, np.nan)
+        return df.sub(mean, axis=0).div(std, axis=0)
+
+    coverage_z = _cross_zscore(compute_fund_coverage(panel, date_range))
+    change_z = _cross_zscore(compute_crowding_change(panel, date_range))
+
+    if market_cap_wide is not None:
+        value_z = _cross_zscore(compute_fund_crowding_value(panel, market_cap_wide, date_range))
+        common_idx = coverage_z.index.intersection(value_z.index).intersection(change_z.index)
+        common_col = coverage_z.columns.intersection(value_z.columns).intersection(change_z.columns)
+        composite = (
+            w_cov * coverage_z.loc[common_idx, common_col]
+            + w_val * value_z.loc[common_idx, common_col]
+            + w_chg * change_z.loc[common_idx, common_col]
+        )
+    else:
+        # 无市值数据：coverage 和 change 重新分配权重
+        adj_w_cov = w_cov / (w_cov + w_chg)
+        adj_w_chg = w_chg / (w_cov + w_chg)
+        common_idx = coverage_z.index.intersection(change_z.index)
+        common_col = coverage_z.columns.intersection(change_z.columns)
+        composite = (
+            adj_w_cov * coverage_z.loc[common_idx, common_col]
+            + adj_w_chg * change_z.loc[common_idx, common_col]
+        )
+
+    return _cross_zscore(composite)
+
+
+# ─────────────────────────────────────────────
+# 最小验证（mock 数据）
+# ─────────────────────────────────────────────
+
+if __name__ == "__main__":
+    np.random.seed(42)
+
+    print("验证 fund_crowding_factor 模块（mock 数据）...")
+
+    # 构造 mock 季度面板
+    periods = pd.date_range("2020-03-31", periods=16, freq="QE")
+    symbols = [f"{i:06d}" for i in range(1, 31)]
+
+    rows = []
+    for period in periods:
+        for sym in symbols:
+            rows.append({
+                "period": period,
+                "symbol": sym,
+                "n_funds": max(0, int(np.random.poisson(15))),
+                "total_hold_value": max(0, np.random.exponential(5000)),
+            })
+    mock_panel = pd.DataFrame(rows)
+
+    date_range = pd.bdate_range("2020-01-01", "2024-12-31")
+
+    # 测试 coverage 因子
+    cov = compute_fund_coverage(mock_panel, date_range)
+    assert cov.shape == (len(date_range), len(symbols))
+    assert (cov <= 0).all().all(), "coverage 因子取负后应全部 <= 0"
+    print(f"✅ fund_coverage  形状: {cov.shape} | 非空比例: {cov.notna().mean().mean():.1%}")
+
+    # 测试 change 因子
+    chg = compute_crowding_change(mock_panel, date_range)
+    assert chg.shape == (len(date_range), len(symbols))
+    print(f"✅ crowding_change 形状: {chg.shape} | 非空比例: {chg.notna().mean().mean():.1%}")
+
+    # 测试合成（无市值数据）
+    comp = compute_composite_crowding(mock_panel, date_range, market_cap_wide=None)
+    assert comp.shape[1] == len(symbols)
+    cross_mean = comp.mean(axis=1).abs().mean()
+    assert cross_mean < 1.0, f"合成因子截面均值偏大: {cross_mean:.4f}"
+    print(f"✅ composite_crowding 形状: {comp.shape} | 截面均值绝对值: {cross_mean:.4f}")
+    print("✅ fund_crowding_factor 验证通过")

--- a/research/factors/northbound_flow/northbound_flow_factor.py
+++ b/research/factors/northbound_flow/northbound_flow_factor.py
@@ -1,0 +1,321 @@
+"""
+北向资金因子模块
+
+核心假设
+--------
+陆股通北向资金（沪股通 + 深股通）以外资机构为主，相对 A 股散户属于
+"聪明钱"——持仓周期长、基本面驱动、跨市场定价能力强。
+
+当外资持续净增持某只股票时：
+  1. 信息优势：外资基本面研究更早发现低估
+  2. 增量资金：持续买入形成价格支撑
+  3. 信号传导：北向数据公开后本土机构跟进
+
+因子定义
+--------
+Δholding_pct_N = (持股比例_t - 持股比例_{t-N}) / N
+
+即：过去 N 个交易日的北向持股占比日均变化量。
+正值 = 北向在净增持，负值 = 净减持。
+
+数据来源
+--------
+akshare: stock_hsgt_hold_stock_em（沪/深股通逐日持股快照）
+
+⚠️  重要：历史数据构建方式
+----------------------------------------
+akshare 的北向持股接口返回的是**当天快照**，没有完整历史。
+本模块提供两套机制：
+  1. `snapshot_today()` — 获取今日快照并追加到本地 parquet
+  2. `load_historical_wide()` — 读取已积累的历史数据，构建因子宽表
+
+建议从 daily_signal.py 的 post-run hook 中每日调用 snapshot_today()，
+积累约 60 个交易日后，本因子的 N=20/N=60 版本开始有效。
+
+初始回测替代方案
+--------------
+如需立即回测（无积累历史），可用以下两个代理：
+  - 大单净流入比例（主力资金，来自 alpha_factors 的 apm_overnight 近似）
+  - 北向每日净买卖额（指数级别，来自 akshare stock_hsgt_north_net_flow_in_em）
+  这两个都是横截面代理，精度低于真实持股比例变化。
+"""
+
+import warnings
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+_SNAPSHOT_PATH = Path(__file__).parent.parent.parent.parent / "data" / "raw" / "northbound_holdings.parquet"
+_SNAPSHOT_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+# ─────────────────────────────────────────────
+# 数据采集（每日快照）
+# ─────────────────────────────────────────────
+
+def snapshot_today(save: bool = True) -> pd.DataFrame:
+    """
+    获取今日北向持股快照（沪股通 + 深股通合并）
+
+    参数
+    ----
+    save : True 则追加写入本地 parquet（用于历史积累）
+
+    返回
+    ----
+    DataFrame，列：date, symbol, holding_pct（持股占 A 股比例，%）
+    """
+    import time
+    try:
+        import akshare as ak
+    except ImportError:
+        raise ImportError("请先安装 akshare: pip install akshare")
+
+    today = pd.Timestamp.today().normalize()
+    frames = []
+
+    for board in ["沪股通", "深股通"]:
+        try:
+            raw = ak.stock_hsgt_hold_stock_em(symbol=board)
+            time.sleep(0.5)
+        except Exception as e:
+            warnings.warn(f"[northbound] {board} 持股快照拉取失败: {e}")
+            continue
+
+        # 列名映射（东方财富接口）
+        col_map = {
+            "股票代码": "symbol",
+            "持股占A股百分比": "holding_pct",   # 占该股 A 股总股本的比例（%）
+        }
+        available = {k: v for k, v in col_map.items() if k in raw.columns}
+        if "股票代码" not in available:
+            warnings.warn(f"[northbound] {board} 列名不匹配，跳过")
+            continue
+
+        df = raw[list(available.keys())].rename(columns=available).copy()
+        df["symbol"] = df["symbol"].astype(str).str.zfill(6)
+        df["holding_pct"] = pd.to_numeric(df["holding_pct"], errors="coerce")
+        df["date"] = today
+        frames.append(df[["date", "symbol", "holding_pct"]])
+
+    if not frames:
+        return pd.DataFrame(columns=["date", "symbol", "holding_pct"])
+
+    today_df = pd.concat(frames, ignore_index=True)
+    # 同一股票在沪/深股通都有时，持股比例合并（理论上不重叠，但 SUM 保险）
+    today_df = (
+        today_df.groupby(["date", "symbol"], as_index=False)["holding_pct"].sum()
+    )
+
+    if save:
+        _append_snapshot(today_df)
+
+    return today_df
+
+
+def _append_snapshot(today_df: pd.DataFrame) -> None:
+    """将今日快照追加到本地 parquet（幂等：同一日期重复写入会覆盖）"""
+    if _SNAPSHOT_PATH.exists():
+        existing = pd.read_parquet(_SNAPSHOT_PATH)
+        today = today_df["date"].iloc[0]
+        existing = existing[existing["date"] != today]
+        combined = pd.concat([existing, today_df], ignore_index=True)
+    else:
+        combined = today_df
+
+    combined = combined.sort_values(["date", "symbol"]).reset_index(drop=True)
+    combined.to_parquet(_SNAPSHOT_PATH, index=False)
+
+
+# ─────────────────────────────────────────────
+# 因子计算（从积累的历史数据）
+# ─────────────────────────────────────────────
+
+def load_holding_history() -> pd.DataFrame:
+    """
+    读取本地积累的北向持股历史快照
+
+    返回
+    ----
+    DataFrame，列：date, symbol, holding_pct
+    """
+    if not _SNAPSHOT_PATH.exists():
+        raise FileNotFoundError(
+            f"北向持股历史文件不存在: {_SNAPSHOT_PATH}\n"
+            "请先运行 snapshot_today() 积累至少 30 个交易日数据。"
+        )
+    return pd.read_parquet(_SNAPSHOT_PATH)
+
+
+def build_holding_wide(
+    symbols: list = None,
+    start: str = None,
+    end: str = None,
+) -> pd.DataFrame:
+    """
+    构建北向持股比例宽表（date × symbol）
+
+    参数
+    ----
+    symbols : 股票代码列表（None = 全部）
+    start   : 开始日期（None = 全部）
+    end     : 结束日期（None = 全部）
+
+    返回
+    ----
+    DataFrame，index=date，columns=symbol，值=持股比例（%）
+    """
+    hist = load_holding_history()
+    if symbols is not None:
+        hist = hist[hist["symbol"].isin(symbols)]
+    if start is not None:
+        hist = hist[hist["date"] >= pd.Timestamp(start)]
+    if end is not None:
+        hist = hist[hist["date"] <= pd.Timestamp(end)]
+
+    wide = hist.pivot(index="date", columns="symbol", values="holding_pct")
+    wide = wide.sort_index()
+    return wide
+
+
+def compute_northbound_flow(
+    holding_wide: pd.DataFrame,
+    lookback: int = 20,
+) -> pd.DataFrame:
+    """
+    计算北向持股变化因子（日均持股比例变化量）
+
+    因子 = (持股比例_t - 持股比例_{t-lookback}) / lookback
+
+    参数
+    ----
+    holding_wide : 北向持股比例宽表 (date × symbol)，来自 build_holding_wide()
+    lookback     : 回看窗口（交易日），建议 5 / 20 / 60
+
+    返回
+    ----
+    宽表 (date × symbol)，值为日均持股比例变化（单位：%/日）
+    正值 = 北向净增持，负值 = 净减持
+    """
+    delta = holding_wide - holding_wide.shift(lookback)
+    flow = delta / lookback
+    return flow
+
+
+def compute_northbound_zscore(
+    holding_wide: pd.DataFrame,
+    window: int = 60,
+) -> pd.DataFrame:
+    """
+    计算北向持股比例的滚动 Z-score（相对历史水平的偏离程度）
+
+    因子 = (持股比例_t - 滚动均值) / 滚动标准差
+
+    适合捕捉"相对历史异常高/低的北向仓位"，而非单纯方向变化。
+
+    参数
+    ----
+    holding_wide : 北向持股比例宽表 (date × symbol)
+    window       : 滚动窗口（交易日）
+
+    返回
+    ----
+    宽表 (date × symbol)，值为 Z-score
+    正值 = 北向仓位处于历史高位（持续买入后），负值 = 历史低位
+    """
+    roll_mean = holding_wide.rolling(window, min_periods=window // 2).mean()
+    roll_std = holding_wide.rolling(window, min_periods=window // 2).std()
+    roll_std = roll_std.replace(0, np.nan)
+    return (holding_wide - roll_mean) / roll_std
+
+
+def compute_northbound_composite(
+    holding_wide: pd.DataFrame,
+    short_window: int = 20,
+    long_window: int = 60,
+    weights: tuple = (0.5, 0.5),
+) -> pd.DataFrame:
+    """
+    合成北向资金因子（短期流量 + 长期 Z-score）
+
+    short_window 捕捉近期动态变化，long_window 捕捉结构性持仓水平，
+    两者截面 z-score 后加权合成。
+
+    参数
+    ----
+    holding_wide : 北向持股比例宽表 (date × symbol)
+    short_window : 短期流量窗口（默认 20 日）
+    long_window  : Z-score 窗口（默认 60 日）
+    weights      : (w_flow, w_zscore)，合计须为 1
+
+    返回
+    ----
+    宽表 (date × symbol)，合成因子值
+    """
+    assert abs(sum(weights) - 1.0) < 1e-9, "权重之和必须为 1"
+    w_f, w_z = weights
+
+    flow = compute_northbound_flow(holding_wide, lookback=short_window)
+    zscore = compute_northbound_zscore(holding_wide, window=long_window)
+
+    def _cross_zscore(df: pd.DataFrame) -> pd.DataFrame:
+        mean = df.mean(axis=1)
+        std = df.std(axis=1).replace(0, np.nan)
+        return df.sub(mean, axis=0).div(std, axis=0)
+
+    flow_z = _cross_zscore(flow)
+    zscore_z = _cross_zscore(zscore)
+
+    common_idx = flow_z.index.intersection(zscore_z.index)
+    common_col = flow_z.columns.intersection(zscore_z.columns)
+
+    composite = (
+        w_f * flow_z.loc[common_idx, common_col]
+        + w_z * zscore_z.loc[common_idx, common_col]
+    )
+    return _cross_zscore(composite)
+
+
+# ─────────────────────────────────────────────
+# 最小验证（mock 数据）
+# ─────────────────────────────────────────────
+
+if __name__ == "__main__":
+    np.random.seed(42)
+
+    print("验证 northbound_flow_factor 模块（mock 数据）...")
+
+    # 构造模拟持股宽表（100 个交易日 × 20 只股票）
+    dates = pd.bdate_range("2024-01-01", periods=100)
+    symbols = [f"{i:06d}" for i in range(1, 21)]
+
+    # 模拟：持股比例在 0%~5% 之间随机游走
+    np.random.seed(42)
+    noise = np.random.randn(100, 20) * 0.05
+    level = np.abs(np.random.randn(20) * 2 + 1)  # 初始持股比例
+    holding_raw = level + noise.cumsum(axis=0)
+    holding_raw = np.clip(holding_raw, 0, 10)  # 持股比例不超过 10%
+
+    holding_wide = pd.DataFrame(holding_raw, index=dates, columns=symbols)
+
+    # 测试流量因子
+    flow_20 = compute_northbound_flow(holding_wide, lookback=20)
+    assert flow_20.shape == holding_wide.shape
+    assert flow_20.iloc[:20].isna().all().all()  # 前 20 行应为 NaN
+    print(f"✅ northbound_flow(20日)  形状: {flow_20.shape} | 非空比例: {flow_20.notna().mean().mean():.1%}")
+
+    # 测试 Z-score 因子
+    zs = compute_northbound_zscore(holding_wide, window=60)
+    assert zs.shape == holding_wide.shape
+    print(f"✅ northbound_zscore(60日) 形状: {zs.shape} | 非空比例: {zs.notna().mean().mean():.1%}")
+
+    # 测试合成
+    comp = compute_northbound_composite(holding_wide)
+    assert comp.shape[1] == len(symbols)
+    print(f"✅ northbound_composite  形状: {comp.shape} | 非空比例: {comp.notna().mean().mean():.1%}")
+
+    print("✅ northbound_flow_factor 验证通过")
+    print()
+    print("⚠️  回测前提：需先通过 snapshot_today() 积累至少 30 个交易日的真实数据")
+    print("   建议在 scripts/daily_run.sh 中加入: python -c 'from research.factors.northbound_flow.northbound_flow_factor import snapshot_today; snapshot_today()'")


### PR DESCRIPTION
Closes #20

## 做了什么

### 三个新因子模块

**盈利质量（`earnings_quality_factor.py`）**
- 子因子 1：CFO/NI（净利润 ≤ 0 置 NaN，截尾 [-2, 5]）
- 子因子 2：-Accruals/TA（截尾 [-0.5, 0.5]，取负）
- 合成：截面 z-score 等权加权，shift(1)+ffill 防前视偏差
- 数据：`ak.stock_cash_flow_sheet_by_report_em`，7天缓存

**北向资金（`northbound_flow_factor.py`）**
- 每日快照积累机制（akshare 无历史接口）
- 子因子：Δholding_pct/N 流量 + 滚动 Z-score 持仓水平
- 合成：截面 z-score 0.5/0.5 加权

**基金拥挤度（`fund_crowding_factor.py`）**
- 季度面板：`ak.stock_report_fund_hold`
- 子因子：-n_funds 覆盖度 + -(Δn_funds) 撤出信号 + -(基金市值/流通市值)
- 无市值数据时降级到双因子合成

### 回测 notebook
`12_earnings_quality_factor.ipynb` — 完整 IC 分析 + 分层回测 + 相关性检验

### 文档
`NEW_FACTORS_BACKTEST_GUIDE.md` — 三步验证流程 + 数据状态表 + 代码片段

## 怎么测试

```bash
# 验证三个模块（mock 数据）
python research/factors/earnings_quality/earnings_quality_factor.py
python research/factors/northbound_flow/northbound_flow_factor.py
python research/factors/fund_crowding/fund_crowding_factor.py
```

真实回测先跑 notebook 第 2 格（拉取现金流数据），首次约 5~10 分钟。